### PR TITLE
feat: add common IsAdminUser permission

### DIFF
--- a/Backend/accounts/permissions.py
+++ b/Backend/accounts/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsAdminUser(BasePermission):
+    """
+    Allows access only to admin users (role="admin").
+    """
+    def has_permission(self, request, view):
+        user = request.user
+        return user and user.is_authenticated and user.role == "admin"

--- a/Backend/dashboard/views/v1.py
+++ b/Backend/dashboard/views/v1.py
@@ -1,6 +1,7 @@
 from rest_framework.generics import ListAPIView, UpdateAPIView
-from rest_framework.permissions import IsAdminUser
+# from rest_framework.permissions import IsAdminUser
 
+from accounts.permissions import IsAdminUser
 from tasks.models import Task
 from ..pagination import StandardResultsSetPagination
 from accounts.models import User


### PR DESCRIPTION
- Introduces a custom permission class to specifically checks for "admin" role on the user model.
- Replaces the default rest_framework IsAdminUser permission, ensuring admin access is based on the application's user roles.

Fixes #4